### PR TITLE
API without args array

### DIFF
--- a/examples/01_typescript/src/App.tsx
+++ b/examples/01_typescript/src/App.tsx
@@ -125,8 +125,7 @@ const CODES = [
 ]
 
 const [languageAtom] = atomsWithQuery(
-  (get) => [
-    `
+  `
 query($code: ID!) {
   language(code: $code) {
     code
@@ -136,8 +135,8 @@ query($code: ID!) {
   }
 }
 `,
-    { code: get(codeAtom) },
-  ],
+  (get) => ({ code: get(codeAtom) }),
+  undefined,
   () => client
 )
 

--- a/src/atomsWithMutation.ts
+++ b/src/atomsWithMutation.ts
@@ -12,11 +12,11 @@ import type { Subject } from 'wonka'
 import { clientAtom } from './clientAtom'
 import { createAtoms } from './common'
 
-type Action<Data, Variables extends AnyVariables> = readonly [
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-  variables: Variables,
-  context?: Partial<OperationContext>
-]
+type Action<Data, Variables extends AnyVariables> = {
+  readonly query: DocumentNode | TypedDocumentNode<Data, Variables> | string
+  readonly variables: Variables
+  readonly context?: Partial<OperationContext>
+}
 
 export function atomsWithMutation<Data, Variables extends AnyVariables>(
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
@@ -43,7 +43,9 @@ export function atomsWithMutation<Data, Variables extends AnyVariables>(
       return subject.source
     },
     async (action, client) => {
-      const result = await client.mutation(...action).toPromise()
+      const result = await client
+        .mutation(action.query, action.variables, action.context)
+        .toPromise()
       const subject = subjectCache.get(client)
       subject?.next(result)
     }

--- a/src/atomsWithQuery.ts
+++ b/src/atomsWithQuery.ts
@@ -10,25 +10,21 @@ import type { Getter, WritableAtom } from 'jotai'
 import { clientAtom } from './clientAtom'
 import { createAtoms } from './common'
 
-type Args<Data, Variables extends AnyVariables> = readonly [
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-  variables: Variables,
-  context?: Partial<OperationContext>
-]
-
 type Action = {
-  type: 'refetch'
+  readonly type: 'refetch'
 }
 
 export function atomsWithQuery<Data, Variables extends AnyVariables>(
-  getArgs: (get: Getter) => Args<Data, Variables>,
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+  getVariables: (get: Getter) => Variables,
+  getContext?: (get: Getter) => Partial<OperationContext>,
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ): readonly [
   dataAtom: WritableAtom<Data, Action>,
   statusAtom: WritableAtom<OperationResult<Data, Variables>, Action>
 ] {
   return createAtoms(
-    getArgs,
+    (get) => [query, getVariables(get), getContext?.(get)] as const,
     getClient,
     (client, args) => client.query(...args),
     (action, _client, refresh) => {

--- a/src/atomsWithSubscription.ts
+++ b/src/atomsWithSubscription.ts
@@ -10,25 +10,21 @@ import type { Getter, WritableAtom } from 'jotai'
 import { clientAtom } from './clientAtom'
 import { createAtoms } from './common'
 
-type Args<Data, Variables extends AnyVariables> = readonly [
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-  variables: Variables,
-  context?: Partial<OperationContext>
-]
-
 type Action = {
-  type: 'refetch'
+  readonly type: 'refetch'
 }
 
 export function atomsWithSubscription<Data, Variables extends AnyVariables>(
-  getArgs: (get: Getter) => Args<Data, Variables>,
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+  getVariables: (get: Getter) => Variables,
+  getContext?: (get: Getter) => Partial<OperationContext>,
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ): readonly [
   dataAtom: WritableAtom<Data, Action>,
   statusAtom: WritableAtom<OperationResult<Data, Variables>, Action>
 ] {
   return createAtoms(
-    getArgs,
+    (get) => [query, getVariables(get), getContext?.(get)] as const,
     getClient,
     (client, args) => client.subscription(...args),
     (action, _client, refresh) => {


### PR DESCRIPTION
fix #3 

It was a little weird design choice to expose `Args` type. This should be better.