### PR TITLE
fix: statusAtom should not suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- fix: statusAtom should not suspend #6
 
 ## [0.3.0] - 2022-11-15
 ### Changed

--- a/__tests__/atomsWithMutation_spec.tsx
+++ b/__tests__/atomsWithMutation_spec.tsx
@@ -91,7 +91,7 @@ describe('error handling', () => {
       const [status, mutate] = useAtom(mutateAtom)
       // TODO revisit this with jotai v2
       useEffect(() => {
-        if (status.state === 'hasData' && status.data.error) {
+        if (status.state === 'hasData' && status.data?.error) {
           errored = true
         }
       }, [status])

--- a/__tests__/atomsWithQuery_spec.tsx
+++ b/__tests__/atomsWithQuery_spec.tsx
@@ -339,10 +339,10 @@ describe('error handling', () => {
 
     const Counter = () => {
       const [result] = useAtom(countAtom)
-      if (result.error) {
+      if (result?.error) {
         throw result.error
       }
-      return <div>count: {result.data?.id}</div>
+      return <div>count: {result?.data?.id ?? 'no data'}</div>
     }
 
     const { findByText } = render(
@@ -353,7 +353,7 @@ describe('error handling', () => {
       </ErrorBoundary>
     )
 
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(0)
     await findByText('errored')
   })
@@ -372,12 +372,12 @@ describe('error handling', () => {
     const Counter = () => {
       const [result, dispatch] = useAtom(countAtom)
       const refetch = () => dispatch({ type: 'refetch' })
-      if (result.error) {
+      if (result?.error) {
         throw result.error
       }
       return (
         <>
-          <div>count: {result.data?.id}</div>
+          <div>count: {result?.data?.id ?? 'no data'}</div>
           <button onClick={refetch}>refetch</button>
         </>
       )
@@ -403,25 +403,25 @@ describe('error handling', () => {
       </>
     )
 
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(0)
     await findByText('errored')
 
     willThrowError = false
     fireEvent.click(getByText('retry'))
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(1)
     await findByText('count: 1')
 
     willThrowError = true
     fireEvent.click(getByText('refetch'))
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(2)
     await findByText('errored')
 
     willThrowError = false
     fireEvent.click(getByText('retry'))
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(3)
     await findByText('count: 3')
   })

--- a/__tests__/atomsWithSubscription_spec.tsx
+++ b/__tests__/atomsWithSubscription_spec.tsx
@@ -276,10 +276,10 @@ describe('error handling', () => {
 
     const Counter = () => {
       const [result] = useAtom(countAtom)
-      if (result.error) {
+      if (result?.error) {
         throw result.error
       }
-      return <div>count: {result.data?.count}</div>
+      return <div>count: {result?.data?.count ?? 'no data'}</div>
     }
 
     const { findByText } = render(
@@ -290,7 +290,7 @@ describe('error handling', () => {
       </ErrorBoundary>
     )
 
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(0)
     await findByText('errored')
   })
@@ -315,12 +315,12 @@ describe('error handling', () => {
     const Counter = () => {
       const [result, dispatch] = useAtom(countAtom)
       const refetch = () => dispatch({ type: 'refetch' })
-      if (result.error) {
+      if (result?.error) {
         throw result.error
       }
       return (
         <>
-          <div>count: {result.data?.count}</div>
+          <div>count: {result?.data?.count ?? 'no data'}</div>
           <button onClick={refetch}>refetch</button>
         </>
       )
@@ -346,13 +346,13 @@ describe('error handling', () => {
       </>
     )
 
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(0)
     await findByText('errored')
 
     willThrowError = false
     fireEvent.click(getByText('retry'))
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(0)
     await findByText('count: 0')
     subject.next(1)
@@ -362,13 +362,13 @@ describe('error handling', () => {
 
     willThrowError = true
     fireEvent.click(getByText('refetch'))
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(0)
     await findByText('errored')
 
     willThrowError = false
     fireEvent.click(getByText('retry'))
-    await findByText('loading')
+    await findByText('count: no data')
     subject.next(0)
     await findByText('count: 0')
     subject.next(1)

--- a/src/atomsWithMutation.ts
+++ b/src/atomsWithMutation.ts
@@ -23,7 +23,7 @@ export function atomsWithMutation<Data, Variables extends AnyVariables>(
 ): readonly [
   dataAtom: WritableAtom<Data, Action<Data, Variables>, Promise<void>>,
   statusAtom: WritableAtom<
-    OperationResult<Data, Variables>,
+    OperationResult<Data, Variables> | undefined,
     Action<Data, Variables>,
     Promise<void>
   >

--- a/src/atomsWithQuery.ts
+++ b/src/atomsWithQuery.ts
@@ -21,7 +21,7 @@ export function atomsWithQuery<Data, Variables extends AnyVariables>(
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ): readonly [
   dataAtom: WritableAtom<Data, Action>,
-  statusAtom: WritableAtom<OperationResult<Data, Variables>, Action>
+  statusAtom: WritableAtom<OperationResult<Data, Variables> | undefined, Action>
 ] {
   return createAtoms(
     (get) => [query, getVariables(get), getContext?.(get)] as const,

--- a/src/atomsWithSubscription.ts
+++ b/src/atomsWithSubscription.ts
@@ -21,7 +21,7 @@ export function atomsWithSubscription<Data, Variables extends AnyVariables>(
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ): readonly [
   dataAtom: WritableAtom<Data, Action>,
-  statusAtom: WritableAtom<OperationResult<Data, Variables>, Action>
+  statusAtom: WritableAtom<OperationResult<Data, Variables> | undefined, Action>
 ] {
   return createAtoms(
     (get) => [query, getVariables(get), getContext?.(get)] as const,

--- a/src/common.ts
+++ b/src/common.ts
@@ -31,9 +31,11 @@ export const createAtoms = <
   })
 
   const baseStatusAtom = atom((get) => {
-    const source = get(sourceAtom)
+    const source = get(sourceAtom) as Source<Result | undefined>
     const observable = pipe(source, toObservable)
-    const resultAtom = atomWithObservable(() => observable)
+    const resultAtom = atomWithObservable(() => observable, {
+      initialValue: undefined,
+    })
     return resultAtom
   })
 


### PR DESCRIPTION
https://jotai.org/docs/integrations/urql

<img width="614" alt="image" src="https://user-images.githubusercontent.com/490574/202888152-dd5cd91f-72fc-4644-a59a-3cfffcdaa56b.png">

says "`statusAtom` doesn't require Suspnse." (oops, typo found.)

This is to follow the ground rule.