### PR TITLE
Defer evaluation of the variables if query is paused, add atomWithLazyQuery atom

### DIFF
--- a/src/atomWithLazyQuery.ts
+++ b/src/atomWithLazyQuery.ts
@@ -1,0 +1,60 @@
+import type { AnyVariables } from '@urql/core'
+import { Client, DocumentInput, OperationContext } from '@urql/core'
+import { WritableAtom, atom } from 'jotai/vanilla'
+import type { Getter } from 'jotai/vanilla'
+import { pipe, subscribe } from 'wonka'
+import { clientAtom } from './clientAtom'
+import {
+  InitialOperationResult,
+  urqlReactCompatibleInitialState,
+} from './common'
+
+export type AtomWithLazyQuery<
+  Data,
+  Variables extends AnyVariables
+> = WritableAtom<
+  InitialOperationResult<Data, Variables>,
+  [Variables, Partial<OperationContext>] | [Variables],
+  Promise<InitialOperationResult<Data, Variables>>
+>
+
+export function atomWithLazyQuery<
+  Data = unknown,
+  Variables extends AnyVariables = AnyVariables
+>(
+  query: DocumentInput<Data, Variables>,
+  getClient: (get: Getter) => Client = (get) => get(clientAtom)
+): AtomWithLazyQuery<Data, Variables> {
+  const atomDataBase = atom<InitialOperationResult<Data, Variables>>(
+    urqlReactCompatibleInitialState
+  )
+  atomDataBase.onMount = (setAtom) => {
+    return () => {
+      // Clean up the atom cache on unmount
+      setAtom(urqlReactCompatibleInitialState)
+    }
+  }
+  const atomData = atom<
+    InitialOperationResult<Data, Variables>,
+    [Variables, Partial<OperationContext>] | [Variables],
+    Promise<InitialOperationResult<Data, Variables>>
+  >(
+    (get) => {
+      return get(atomDataBase)
+    },
+    (get, set, ...args) => {
+      const source = getClient(get).query(query, args[0], {
+        requestPolicy: 'network-only',
+        ...(args[1] ? args[1] : {}),
+      })
+      pipe(
+        source,
+        subscribe((result) => set(atomDataBase, result))
+      )
+
+      return source.toPromise()
+    }
+  )
+
+  return atomData
+}

--- a/src/atomWithMutation.ts
+++ b/src/atomWithMutation.ts
@@ -2,20 +2,20 @@ import { DocumentInput } from '@urql/core'
 import type { AnyVariables, Client, OperationContext } from '@urql/core'
 import { atom } from 'jotai/vanilla'
 import type { Getter, WritableAtom } from 'jotai/vanilla'
-import { pipe, subscribe } from 'wonka'
+import { filter, pipe, subscribe } from 'wonka'
 import { clientAtom } from './clientAtom'
 import {
-  type InitialOperationResult,
-  urqlReactCompatibleInitialState,
+  type InitialOperationResultLazy,
+  urqlReactCompatibleInitialStateLazy,
 } from './common'
 
 export type AtomWithMutation<
   Data,
   Variables extends AnyVariables
 > = WritableAtom<
-  InitialOperationResult<Data, Variables>,
+  InitialOperationResultLazy<Data, Variables>,
   [Variables, Partial<OperationContext>] | [Variables],
-  Promise<InitialOperationResult<Data, Variables>>
+  Promise<InitialOperationResultLazy<Data, Variables>>
 >
 
 export function atomWithMutation<
@@ -25,19 +25,19 @@ export function atomWithMutation<
   query: DocumentInput<Data, Variables>,
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ): AtomWithMutation<Data, Variables> {
-  const atomDataBase = atom<InitialOperationResult<Data, Variables>>(
-    urqlReactCompatibleInitialState
+  const atomDataBase = atom<InitialOperationResultLazy<Data, Variables>>(
+    urqlReactCompatibleInitialStateLazy
   )
   atomDataBase.onMount = (setAtom) => {
     return () => {
       // Clean up the atom cache on unmount
-      setAtom(urqlReactCompatibleInitialState)
+      setAtom(urqlReactCompatibleInitialStateLazy)
     }
   }
   const atomData = atom<
-    InitialOperationResult<Data, Variables>,
+    InitialOperationResultLazy<Data, Variables>,
     [Variables, Partial<OperationContext>] | [Variables],
-    Promise<InitialOperationResult<Data, Variables>>
+    Promise<InitialOperationResultLazy<Data, Variables>>
   >(
     (get) => {
       return get(atomDataBase)
@@ -46,10 +46,20 @@ export function atomWithMutation<
       const source = getClient(get).mutation(query, args[0], args[1])
       pipe(
         source,
-        subscribe((result) => set(atomDataBase, result))
+        // This is needed so that the atom gets updated with loading states etc., but not with the final result that will be set by the promise
+        filter((result) => result?.data === undefined),
+        subscribe((result) => set(atomDataBase, { ...result, fetching: true }))
       )
 
-      return source.toPromise()
+      set(atomDataBase, {
+        ...urqlReactCompatibleInitialStateLazy,
+        fetching: true,
+      })
+      return source.toPromise().then((result) => {
+        const mergedResult = { ...result, fetching: false }
+        set(atomDataBase, mergedResult)
+        return mergedResult
+      })
     }
   )
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -41,9 +41,9 @@ export const createAtoms = <Args, Result extends OperationResult, ActionResult>(
   )
 
   const baseStatusAtom = atom((get) => {
-    const args = getArgs(get)
+    const isPaused = getPause(get)
     const client = getClient(get)
-    const source = getPause(get) ? null : execute(client, args)
+    const source = isPaused ? null : execute(client, getArgs(get))
     if (!source) {
       return initialLoadAtom
     }

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,6 +18,25 @@ export type InitialOperationResult<Data, Variables extends AnyVariables> = Omit<
 > & {
   operation: Operation<Data, Variables> | undefined
 }
+
+export type InitialOperationResultLazy<
+  Data,
+  Variables extends AnyVariables
+> = Omit<OperationResult<Data, Variables>, 'operation'> & {
+  operation: Operation<Data, Variables> | undefined
+  fetching: boolean
+}
+export const urqlReactCompatibleInitialStateLazy = {
+  stale: false,
+  // Casting is needed to make typescript chill here as it tries here to be too smart
+  error: undefined as any,
+  data: undefined as any,
+  extensions: undefined as any,
+  hasNext: false,
+  operation: undefined,
+  fetching: false,
+} as InitialOperationResultLazy<any, any>
+
 // This is the same (aside from missing fetching and having hasNext) object shape as urql-react has by default while operation is yet to be triggered/yet to be fetched
 export const urqlReactCompatibleInitialState = {
   stale: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export { atomWithMutation } from './atomWithMutation'
 export type { AtomWithMutation } from './atomWithMutation'
 export { atomWithQuery } from './atomWithQuery'
+export { atomWithLazyQuery } from './atomWithLazyQuery'
+export type { AtomWithLazyQuery } from './atomWithLazyQuery'
 export { atomWithSubscription } from './atomWithSubscription'
 export { clientAtom } from './clientAtom'
 export { suspenseAtom } from './suspenseAtom'

--- a/tests/playwright-tests/smoke.test.ts
+++ b/tests/playwright-tests/smoke.test.ts
@@ -254,6 +254,7 @@ test('smoke - lazy query', async ({ page }) => {
     ],
   })
   await page.getByText('load lazy burgers').click()
+  await expect(page.getByText('loading burgers...')).toBeVisible()
   // New one off result should affect query result updating burger with an id 2
   await expect(page.getByTestId('query-table').getByText('25')).toBeVisible()
   // Same result should be visible within lazy query table

--- a/tests/test-app/src/CacheAndMutations.tsx
+++ b/tests/test-app/src/CacheAndMutations.tsx
@@ -68,6 +68,7 @@ const Burgers = () => {
       </table>
       <h2>Lazy burgers</h2>
       <button onClick={() => lazyLoading({})}>load lazy burgers</button>
+      {burgersLazyOpResult.fetching && <div>loading burgers...</div>}
       {lazyBurgers && (
         <table data-testid="query-lazy-table">
           <tbody>


### PR DESCRIPTION
## Changelog
feat: add `atomWithLazyQuery` that allows for promisifying of a singular query result the same way `atomWithMutation` does
fix: defer evaluation of the variables if paused
feat: add fetching state for mutations and lazy query